### PR TITLE
Remove gap below images

### DIFF
--- a/css/styles.scss
+++ b/css/styles.scss
@@ -113,6 +113,9 @@ main {
 			}
 			.featured {
 				border-bottom: 1px solid $gray-light;
+				img {
+					vertical-align: top;
+				}
 			}
 			.content {
 				padding: 1.5em;


### PR DESCRIPTION
Set `vertical-align: top` to image element.