### PR TITLE
Trigger the blog rebuild every night using CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,31 @@
+version: 2.1
+
+jobs:
+  trigger_rebuild:
+    docker:
+      - image: circleci/node:latest
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - run:
+          name: Set git name & email
+          command: |
+            git config --global user.name "Workflow Bot" && 
+            git config --global user.email "wolf.pack@signavio.com"
+      - run:
+          name: Commit to trigger rebuild
+          command: |
+            git commit --allow-empty -m "[skip ci] Rebuild blog"
+            git push origin master
+
+workflows:
+  nightly_pipeline:
+    # triggers:
+    #   - schedule:
+    #       cron: "0 6 * * *"
+    #       filters:
+    #         branches:
+    #           only:
+    #             - master
+    jobs:
+      - trigger_rebuild

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,12 +20,12 @@ jobs:
 
 workflows:
   nightly_pipeline:
-    # triggers:
-    #   - schedule:
-    #       cron: "0 6 * * *"
-    #       filters:
-    #         branches:
-    #           only:
-    #             - master
+    triggers:
+      - schedule:
+          cron: "0 6 * * *"
+          filters:
+            branches:
+              only:
+                - master
     jobs:
       - trigger_rebuild


### PR DESCRIPTION
I added a nightly CircleCI workflow to trigger the rebuild of the tech blog.
This workflow is the replacement of the [old Jenkins job](https://workflow-ci.signavio.com:8888/job/Rebuild%20tech-blog/) that triggered the rebuild before.

